### PR TITLE
changed fields mapped to CJK for title, subtitle, and author

### DIFF
--- a/quicksearch/solr/cjk/schema.xml
+++ b/quicksearch/solr/cjk/schema.xml
@@ -117,11 +117,11 @@
    <!-- CJK fields -->
 
    <copyField source="text" dest="text_copy_cjk"/>
-   <copyField source="title_txt" dest="title_txt_cjk"/>
-   <copyField source="subtitle_txt" dest="subtitle_txt_cjk"/>
+   <copyField source="title_vern_display" dest="title_txt_cjk"/>
+   <copyField source="subtitle_vern_display" dest="subtitle_txt_cjk"/>
    <copyField source="title_series_txt" dest="title_series_txt_cjk"/>
    <copyField source="title_addl_txt" dest="title_addl_txt_cjk"/>
-   <copyField source="author_txt" dest="author_txt_cjk"/>
+   <copyField source="author_vern_display" dest="author_txt_cjk"/>
    <copyField source="author_addl_txt" dest="author_addl_txt_cjk"/>
    <copyField source="subject_txt" dest="subject_txt_cjk"/>
    <copyField source="pub_place_txt" dest="pub_place_txt_cjk"/>


### PR DESCRIPTION
This changes the fields we use to generate the CJK version of title, subtitle, and author so that they come from the "vern" fields that contain the alternate script.