### PR TITLE
Update Word Delim filter in text_starts_with

### DIFF
--- a/quicksearch/solr/test/ingest/schema.xml
+++ b/quicksearch/solr/test/ingest/schema.xml
@@ -265,7 +265,7 @@
         <filter class="solr.ICUTransformFilterFactory" id="Katakana-Hiragana"/>
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="true" />
-        <filter class="solr.WordDelimiterFilterFactory"
+        <filter class="solr.WordDelimiterGraphFilterFactory"
           splitOnCaseChange="1" generateWordParts="1" catenateWords="1"
           splitOnNumerics="0" generateNumberParts="1" catenateNumbers="1"
           catenateAll="0" preserveOriginal="0" stemEnglishPossessive="0" />

--- a/quicksearch/solr/test/search/schema.xml
+++ b/quicksearch/solr/test/search/schema.xml
@@ -281,7 +281,7 @@
         <filter class="solr.ICUTransformFilterFactory" id="Katakana-Hiragana"/>
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="true" />
-        <filter class="solr.WordDelimiterFilterFactory"
+        <filter class="solr.WordDelimiterGraphFilterFactory"
           splitOnCaseChange="1" generateWordParts="1" catenateWords="1"
           splitOnNumerics="0" generateNumberParts="1" catenateNumbers="1"
           catenateAll="0" preserveOriginal="0" stemEnglishPossessive="0" />


### PR DESCRIPTION
This is a small change to fix an issue with a few documents.

Solr wouldn't ingest some documents due to some interaction between the CJK filter and the word delimiter for some titles with non-latin characters.

Sample documents with errors: 
11106237
8185768
h100036175