### PR TITLE
Adds dynamic field for use with highlighting

### DIFF
--- a/quicksearch/solr/upgrade/ingest/schema.xml
+++ b/quicksearch/solr/upgrade/ingest/schema.xml
@@ -38,6 +38,7 @@
 
    <field name="cjk" type="text_cjk" indexed="true" stored="true" multiValued="false"/>
    <dynamicField name="*_cjk" type="text_cjk"   indexed="true"  stored="true" multiValued="true"/>
+   <dynamicField name="*_hl" type="text_general" indexed="true" stored="true" multiValued="true"/>
 
 
    <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>

--- a/quicksearch/solr/upgrade/ingest/solrconfig.xml
+++ b/quicksearch/solr/upgrade/ingest/solrconfig.xml
@@ -90,6 +90,7 @@
 
             <str name="q.alt">*:*</str>
             <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+            <str name="hl.method">unified</str>
 
             <!-- this qf and pf are used by default, if not otherwise specified by
                  client. The default blacklight_config will use these for the
@@ -122,7 +123,12 @@
                 text_copy_cjk
                 abstract_facet,
                 access_restrictions_txt
-
+                title_hl
+                author_hl
+                container_hl
+                subject_hl       
+                description_hl
+                abstract_hl
             </str>
             <str name="pf">
                 cjk^100001
@@ -370,6 +376,7 @@
             <!--<str name="q.alt">*:*</str>-->
             <str name="df">text</str>
             <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+            <str name="hl.method">unified</str>
 
             <!-- this qf and pf are used by default, if not otherwise specified by
                  client. The default blacklight_config will use these for the
@@ -404,6 +411,12 @@
                 ancestor_display_strings_txt
                 abstract_facet
                 access_restrictions_txt
+                title_hl
+                author_hl
+                container_hl
+                subject_hl       
+                description_hl
+                abstract_hl
             </str>
             <str name="pf">
                 cjk^100001

--- a/quicksearch/solr/upgrade/search/schema.xml
+++ b/quicksearch/solr/upgrade/search/schema.xml
@@ -38,6 +38,7 @@
 
    <field name="cjk" type="text_cjk" indexed="true" stored="true" multiValued="false"/>
    <dynamicField name="*_cjk" type="text_cjk"   indexed="true"  stored="true" multiValued="true"/>
+   <dynamicField name="*_hl" type="text_general" indexed="true" stored="true" multiValued="true"/>
 
 
    <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>

--- a/quicksearch/solr/upgrade/search/solrconfig.xml
+++ b/quicksearch/solr/upgrade/search/solrconfig.xml
@@ -232,6 +232,7 @@
 
             <str name="q.alt">*:*</str>
             <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+            <str name="hl.method">unified</str>
 
             <!-- this qf and pf are used by default, if not otherwise specified by
                  client. The default blacklight_config will use these for the
@@ -260,6 +261,12 @@
                 pub_name_txt_cjk^1000
                 text
                 text_copy_cjk
+                title_hl
+                author_hl
+                container_hl
+                subject_hl       
+                description_hl
+                abstract_hl
             </str>
             <str name="pf">
                 cjk^100001
@@ -490,6 +497,7 @@
             <!--<str name="q.alt">*:*</str>-->
             <str name="df">text</str>
             <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+            <str name="hl.method">unified</str>
 
             <!-- this qf and pf are used by default, if not otherwise specified by
                  client. The default blacklight_config will use these for the
@@ -520,6 +528,12 @@
                 text_copy_cjk
                 container_txt
                 ancestor_display_strings_txt
+                title_hl
+                author_hl
+                container_hl
+                subject_hl       
+                description_hl
+                abstract_hl
             </str>
             <str name="pf">
                 cjk^100001


### PR DESCRIPTION
Configures solr to use the "unified" highlighter
Adds fields that may be needed for DCS to the qf lists so matching works